### PR TITLE
Revert cron scheduled time

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: Cron
 
 on:
   schedule:
-    - cron: "7 10-23/12 * * *"
+    - cron: "27 6 * * *"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## What's this PR do?
Small tweak in the cron workflow that reverts the scheduled time back to what it was before #11.

## Why are we doing this?
This scheduled time is currently the same as the cronjob for [city-scrapers-cle](https://github.com/City-Bureau/city-scrapers-cle/blob/c2cb3fa08c30da032d45d4f0f5bdd4f67b06d4ee/.github/workflows/cron.yml#L5). It occurs to me that this cron should be at a different time to reduce the chance we hit github's concurrency limits for github actions.

## Steps to manually test
n/a

## Are there any smells or added technical debt to note?
n/a
