### PR TITLE
Fix scrapy-sentry-errors misconfiguration

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=False &
+pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=True &
 
 # Output to the screen every 9 minutes to prevent a travis timeout
 # https://stackoverflow.com/a/40800348

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -31,7 +31,7 @@ EXTENSIONS = {
     "city_scrapers_core.extensions.AzureBlobStatusExtension": 100,
     # "city_scrapers_core.extensions.S3StatusExtension": 100,
     # "city_scrapers_core.extensions.GCSStatusExtension": 100,
-    "scrapy_sentry.extensions.Errors": 10,
+    "scrapy_sentry_errors.extensions.Errors": 10,
     "scrapy.extensions.closespider.CloseSpider": None,
 }
 


### PR DESCRIPTION
## What's this PR do?

Fixes a misconfiguration issue with the `scrapy-sentry-errors` package that was introduced in #11 as a replacement to `scrapy-sentry`.

## Why are we doing this? 

The current misconfiguration hasn't caused failures because there are no spiders in this repo yet.

## Steps to manually test

N/A

## Are there any smells or added technical debt to note? 
- Not tech debt, but just a note that this PR included adding `SENTRY_DSN` to the secrets for this repo's github actions.