### PR TITLE
🛠️ Fix: Moves keepalive task to cron workflow from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,3 @@ jobs:
           git diff-index --name-only --diff-filter=d $(git merge-base HEAD ${{ github.base_ref }}) | \
           grep -Pio '(?<=/spiders/).*(?=\.py)' | \
           xargs pipenv run scrapy validate
-
-      - name: Prevent workflow deactivation
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-          committer_username: "citybureau-bot"
-          committer_email: "documenters@citybureau.org"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,14 +49,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .venv
-          key: pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
-            pip-${{ env.PYTHON_VERSION }}-
-            pip-
+          key: ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Install dependencies
         run: pipenv sync
         env:
-          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }} 
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
       - name: Run scrapers
         run: |
@@ -67,3 +65,9 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           pipenv run scrapy combinefeeds -s LOG_ENABLED=True
+      
+      - name: Prevent workflow deactivation
+        uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          committer_username: "citybureau-bot"
+          committer_email: "documenters@citybureau.org"


### PR DESCRIPTION
## What's this PR do?

Moves keepalive task to cron workflow from ci workflow.

## Why are we doing this?

A few months back I accidentally put the keepalive task – which prevents Github from disabling our actions – in the CI workflow rather than the cron workflow. That meant it wasn't working properly.

## Steps to manually test

n/a

## Are there any smells or added technical debt to note?

n/a
